### PR TITLE
feat: Implement /follow command for spectators

### DIFF
--- a/scripts/modules/commands.lua
+++ b/scripts/modules/commands.lua
@@ -1,4 +1,46 @@
 local Actions = require 'scripts.modules.command-actions'
+local shared = require('utils.shared')
+
+local function validate_player(player)
+    if not player then
+        return false
+    end
+    if not player.valid then
+        return false
+    end
+    if not player.character then
+        return false
+    end
+    if not player.connected then
+        return false
+    end
+    if not game.get_player(player.index) then
+        return false
+    end
+    return true
+end
+
+local function do_follow(cmd)
+    local player = game.player
+    if not player or not validate_player(player) then
+        return
+    end
+    if player.force.name ~= 'player' then
+        player.print('You must be a spectator to use this command.', { color = {r=1,g=0,b=0} })
+        return
+    end
+
+    if not cmd.parameter then
+        return
+    end
+    local target_player = game.get_player(cmd.parameter)
+
+    if not target_player or not validate_player(target_player) then
+        return
+    end
+
+    player.centered_on = target_player.character
+end
 
 for _, command in pairs({
     {
@@ -15,7 +57,14 @@ for _, command in pairs({
         name = 'hax',
         help = 'Unlock all recipes',
         action = Actions.hax
+    },
+    {
+        name = 'follow',
+        help = 'Follows a player',
+        action = do_follow
     }
 }) do
-    commands.add_command( command.name, command.help, command.action)
+    commands.add_command(command.name, command.help, function(cmd)
+        shared.safe_wrap_cmd(cmd, command.action, cmd)
+    end)
 end

--- a/utils/shared.lua
+++ b/utils/shared.lua
@@ -1,7 +1,27 @@
-return {
+local Module = {
     triggers = {
         on_built_turret = 'on_player_built_turret',
         on_cargo_landing_pad_created = 'on_player_built_cargo_landing_pad',
         on_enemy_created = 'on_enemy_created',
     }
 }
+
+function Module.safe_wrap_cmd(cmd, func, ...)
+    local print_fn = game.print
+    if cmd.player_index then
+        local player = game.get_player(cmd.player_index)
+        if player then
+            print_fn = player.print
+        end
+    end
+    local function error_handler(err)
+        log('Error caught: ' .. err)
+        print_fn('Error caught: ' .. err)
+        -- Print the full stack trace to the log
+        log(debug.traceback())
+    end
+    local call_succeeded, result = xpcall(func, error_handler, ...)
+    return result
+end
+
+return Module


### PR DESCRIPTION
Adds a new chat command, /follow, allowing players in the spectator force to follow another player's character. This includes the addition of a safe_wrap_cmd utility for robust command error handling (i.e. a bug in this implementation will not cause the game to crash, it will just print out an error).

The implementation is inspired by the /follow command functionality in Factorio-Biter-Battles.